### PR TITLE
Document time windows -> suggested times alias in public API 1.6.0

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -806,6 +806,58 @@ As a job source, your workflow may require you to create an organization record,
 
 `POST /v3/jobs/factory`
 
+## Add customer-suggested times to a job
+
+> Request
+
+```json
+{
+  "time_windows": [
+    {
+      "start_time": "RFC3339 Timestamp",
+      "end_time": "RFC3339 Timestamp"
+    },
+    {
+      "start_time": "RFC3339 Timestamp",
+      "end_time": "RFC3339 Timestamp"
+    },
+    {
+      "start_time": "RFC3339 Timestamp",
+      "end_time": "RFC3339 Timestamp"
+    }
+  ]
+}
+```
+
+> Response
+
+```json
+{
+  "time_windows": {
+    "job_id": 123,
+    "created_at": "2017-10-21T00:00:00Z",
+    "time_windows": [
+      {
+        "start_time": "RFC3339 Timestamp",
+        "end_time": "RFC3339 Timestamp"
+      },
+      {
+        "start_time": "RFC3339 Timestamp",
+        "end_time": "RFC3339 Timestamp"
+      },
+      {
+        "start_time": "RFC3339 Timestamp",
+        "end_time": "RFC3339 Timestamp"
+      }
+    ]
+  }
+}
+```
+
+Your customer-facing workflow may include a discussion about potential times for a visit from the service provider. In that case, once you create the job, you can send Dispatch up to 3 time windows that will be shown to the dispatcher in the Dispatch application.
+
+`POST /v3/jobs/:job_id/time_windows`
+
 ## List Jobs
 
 > Response


### PR DESCRIPTION
The actual call to create suggested times doesn't make sense from a public perspective (no need to expose that we're creating a draft appointment with the `suggested_times` array). This documents the alias of that request to "time windows" in the public API, so API consumers can send over possible time windows after they create a job.